### PR TITLE
Adding template for simple VM test using cinder+lvm on MOS9

### DIFF
--- a/examples/MOS9-simple-map.yaml
+++ b/examples/MOS9-simple-map.yaml
@@ -1,0 +1,152 @@
+adv_net_template:
+  default:
+    nic_mapping:
+      default:
+        if1: eth0 # admin
+        if2: eth1 # management
+        if3: eth2 # public
+        if4: eth3 # private
+        if5: eth4 # storage
+        if6: eth5 # mesh       
+    templates_for_node_role:
+        controller:
+          - common
+          - public
+          - mesh
+          - private
+        compute:
+          - common
+          - mesh
+          - private
+        cinder:
+          - common
+          - storage
+    network_assignments:
+        storage:
+          ep: br-storage
+        private:
+          ep: br-mesh
+        public:
+          ep: br-ex
+        management:
+          ep: br-mgmt
+        fuelweb_admin:
+          ep: br-fw-admin
+    network_scheme:
+      storage:
+        transformations:
+          - action: add-br
+            name: br-storage
+          - action: add-port
+            bridge: br-storage
+            name: eth4
+        endpoints:
+          - br-storage
+        roles:
+          cinder/iscsi: br-storage
+          swift/replication: br-storage
+          storage: br-storage
+      private:
+        transformations:
+          - action: add-br
+            name: br-prv
+            provider: ovs
+          - action: add-patch
+            bridges:
+            - br-prv
+            - br-eth3
+            provider: ovs
+            mtu: 65000
+        endpoints:
+          - br-prv
+        roles:
+          neutron/private: br-prv
+      mesh:
+        transformations:
+          - action: add-br
+            name: br-mesh
+          - action: add-port
+            bridge: br-mesh
+            name: eth5
+        endpoints:
+          - br-mesh
+        roles:
+          neutron/mesh: br-mesh
+      public:
+        transformations:
+          - action: add-br
+            name: br-pub
+          - action: add-port
+            bridge: br-pub
+            name: eth2
+          - action: add-br
+            name: br-ex
+            provider: ovs
+          - action: add-br
+            name: br-floating
+            provider: ovs
+          - action: add-patch
+            bridges:
+            - br-floating
+            - br-ex
+            provider: ovs
+            mtu: 65000
+          - action: add-patch
+            bridges:
+            - br-ex
+            - br-pub
+            provider: ovs
+            mtu: 65000
+        endpoints:
+          - br-ex
+        roles:
+          public/vip: br-ex
+          neutron/floating: br-floating
+          ex: br-ex
+      common:
+        transformations:
+          - action: add-br
+            name: br-eth3
+          - action: add-br
+            name: br-fw-admin
+          - action: add-br
+            name: br-mgmt
+          - action: add-port
+            bridge: br-fw-admin
+            name: eth0
+          - action: add-port
+            bridge: br-mgmt
+            name: eth1
+          - action: add-port
+            bridge: br-eth3
+            name: eth3
+        endpoints:
+          - br-fw-admin
+          - br-mgmt
+        roles:
+          admin/pxe: br-fw-admin
+          fw-admin: br-fw-admin
+          mongo/db: br-mgmt
+          management: br-mgmt
+          keystone/api: br-mgmt
+          neutron/api: br-mgmt
+          swift/api: br-mgmt
+          sahara/api: br-mgmt
+          ceilometer/api: br-mgmt
+          cinder/api: br-mgmt
+          glance/api: br-mgmt
+          heat/api: br-mgmt
+          nova/api: br-mgmt
+          nova/migration: br-mgmt
+          murano/api: br-mgmt
+          murano/cfapi: br-mgmt
+          horizon: br-mgmt
+          mgmt/api: br-mgmt
+          mgmt/memcache: br-mgmt
+          mgmt/database: br-mgmt
+          mgmt/messaging: br-mgmt
+          mgmt/corosync: br-mgmt
+          mgmt/vip: br-mgmt
+          mgmt/api: br-mgmt
+          ironic/api: br-mgmt
+          ironic/baremetal: br-mgmt


### PR DESCRIPTION
Usualy, we want to try it without ceph on 3vms only (1 fuel, 1 controller, 1 compute)